### PR TITLE
Bonsai skeleton implementation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,25 @@
+skip_commits:
+  message: /^Merge pull request /
+
+build: false
+
+environment:
+  PYTHONIOENCODING: "UTF-8"
+
+  matrix:
+    - PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      CONDA_PY: "37"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
+
+install:
+  - call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+  - python --version
+  - conda config --set always_yes yes
+  - conda update -y conda
+  - conda install -y -c conda-forge <add your conda dependencies here> pytest pytest-cov coveralls
+  - pip install <add any other dependencies not available in conda here>
+  - pip install -e .
+
+test_script:
+  - pytest

--- a/.gitignore
+++ b/.gitignore
@@ -156,9 +156,9 @@ dmypy.json
 .pyre/
 
 # Data
-EXIOBASE_conversion_software/data*/*.xlsb
-EXIOBASE_conversion_software/data*/*.csv
-EXIOBASE_conversion_software/data*/*.rdf
-EXIOBASE_conversion_software/data*/*.ttl
-EXIOBASE_conversion_software/data*/*.nt
+data*/*.xlsb
+data*/*.csv
+data*/*.rdf
+data*/*.ttl
+data*/*.nt
 .vscode/**

--- a/.gitignore
+++ b/.gitignore
@@ -155,10 +155,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-
-data*/*.xlsb
-data*/*.csv
-data*/*.rdf
-data*/*.ttl
-data*/*.nt
+# Data
+EXIOBASE_conversion_software/data*/*.xlsb
+EXIOBASE_conversion_software/data*/*.csv
+EXIOBASE_conversion_software/data*/*.rdf
+EXIOBASE_conversion_software/data*/*.ttl
+EXIOBASE_conversion_software/data*/*.nt
 .vscode/**

--- a/.gitignore
+++ b/.gitignore
@@ -156,9 +156,9 @@ dmypy.json
 .pyre/
 
 # Data
-data*/*.xlsb
-data*/*.csv
-data*/*.rdf
-data*/*.ttl
-data*/*.nt
+EXIOBASE_conversion_software/data*/*.xlsb
+EXIOBASE_conversion_software/data*/*.csv
+EXIOBASE_conversion_software/data*/*.rdf
+EXIOBASE_conversion_software/data*/*.ttl
+EXIOBASE_conversion_software/data*/*.nt
 .vscode/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,52 @@
+language: python
+matrix:
+  include:
+    - language: generic-covered
+      python: 3.7
+      os: osx
+    - python: 3.7
+      dist: xenial
+      os: linux
+python:
+  - "3.7"
+before_install:
+  - if [ $TRAVIS_OS_NAME == "osx" ]; then
+      echo "Running on OS X";
+      echo $(python3 --version);
+      echo $(python --version);
+    else
+      echo "Running on Linux";
+      sudo apt-get update;
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      bash miniconda.sh -b -p $HOME/miniconda;
+      export PATH="$HOME/miniconda/bin:$PATH";
+      hash -r;
+      conda config --set always_yes yes --set changeps1 no;
+      conda config --append channels conda-forge;
+      conda update conda;
+      conda info -a;
+      echo $(python --version);
+    fi
+install:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      conda create -n test-environment python=$TRAVIS_PYTHON_VERSION <add your conda dependencies here> pytest pytest-cov coveralls;
+      source activate test-environment;
+      pip install <add any other dependencies not available in conda here>;
+      pip3 install -e .;
+    else
+      pip3 install -r ci/macos-travis.txt;
+      pip3 install -e .;
+    fi
+script:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      pwd;
+      ls;
+      pytest --cov=<your_library_name>;
+      coveralls;
+      if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+        conda install conda-build anaconda-client conda-verify;
+        bash ci/conda_upload.sh;
+      fi
+    else
+      pytest;
+    fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.4] - 2020-02-03
+
+### Changed
+
+* Restructured repository to allign with the Python Skeleton

--- a/EXIOBASE_conversion_software/__init__.py
+++ b/EXIOBASE_conversion_software/__init__.py
@@ -1,0 +1,21 @@
+__all__ = (
+    "csv2rdf",
+    "excel2csv",
+    "makeRDF",
+)
+
+VERSION = (0, 4)
+__version__ = ".".join(str(v) for v in VERSION)
+
+data_dir = "data"
+
+from .csv2rdf import csv2rdf
+from .excel2csv import excel2csv
+from .makeRDF import makeRDF
+
+
+def conversion(args, script):
+    if script == 'excel2csv':
+        excel2csv(args)
+    elif script == 'csv2rdf':
+        csv2rdf(args)

--- a/EXIOBASE_conversion_software/__init__.py
+++ b/EXIOBASE_conversion_software/__init__.py
@@ -7,7 +7,7 @@ __all__ = (
 VERSION = (0, 4)
 __version__ = ".".join(str(v) for v in VERSION)
 
-data_dir = "data"
+data_dir = "../data"
 
 from .csv2rdf import csv2rdf
 from .excel2csv import excel2csv

--- a/EXIOBASE_conversion_software/bin/csv2rdf_cli.py
+++ b/EXIOBASE_conversion_software/bin/csv2rdf_cli.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Arborist CLI.
+Usage:
+  arborist-cli regenerate <dirpath>
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+"""
+
+import argparse
+from docopt import docopt
+from EXIOBASE_conversion_software import conversion
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert EXIOBASE .csv file to RDF/TTL')
+    parser.add_argument('-i','--input',
+                        dest='csvfile',
+                        required=True,
+                        help='<Required> path to csv file to convert')
+
+    parser.add_argument('-o', '--outdir',
+                        dest='outdir',
+                        default='./',
+                        help='Output directory')
+
+    parser.add_argument('-c', '--code',
+                        dest='code',
+                        required=True,
+                        help='The code of the specific file: HSUP/HUSE/HFD/Other?')
+
+    parser.add_argument('--flowtype',
+                      choices=['input','output'],
+                      required=True,
+                      help='If the flow are input or output of activites')
+
+    parser.add_argument('--format',
+                      choices=['nt','ttl', 'xml'],
+                      default='nt',
+                      help='The output format')
+
+    parser.add_argument('--multifile',
+                      default=100000,
+                      dest="multifile",
+                      help='Create multiple files each with x triples. Restricted to nt format.')
+
+    parser.add_argument('--merge',
+                      dest="merge",
+                      help='If multifile is chosen, merge all nt files')
+
+    args = parser.parse_args()
+
+    try:
+        conversion(args, 'csv2rdf')
+    except KeyboardInterrupt:
+        print("Terminating CLI")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/EXIOBASE_conversion_software/bin/csv2rdf_cli.py
+++ b/EXIOBASE_conversion_software/bin/csv2rdf_cli.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Arborist CLI.
+"""EXIOBASE-conversion-software csv2rdf-cli CLI.
 Usage:
-  arborist-cli regenerate <dirpath>
+  csv2rdf-cli  -i <input/dirpath> -o <output/dirpath>  -c <HSUP/HUSE> --flowtype <input/output>
 Options:
   -h --help     Show this screen.
   --version     Show version.

--- a/EXIOBASE_conversion_software/bin/excel2csv_cli.py
+++ b/EXIOBASE_conversion_software/bin/excel2csv_cli.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Arborist CLI.
+Usage:
+  arborist-cli regenerate <dirpath>
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+"""
+
+import argparse
+from docopt import docopt
+from EXIOBASE_conversion_software import conversion
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert EXIOBASE .xslb file to csv')
+    parser.add_argument('-i','--import',
+                        dest='exfile',
+                        help='<Required> path to file to convert')
+
+    parser.add_argument('-o', '--outdir',
+                        dest='outdir',
+                        default='./',
+                        help='Output directory')
+
+    args = parser.parse_args()
+
+    try:
+        conversion(args, 'excel2csv')
+    except KeyboardInterrupt:
+        print("Terminating CLI")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/EXIOBASE_conversion_software/bin/excel2csv_cli.py
+++ b/EXIOBASE_conversion_software/bin/excel2csv_cli.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Arborist CLI.
+"""EXIOBASE-conversion-software excel2csv CLI.
 Usage:
-  arborist-cli regenerate <dirpath>
+  excel2csv-cli -i <input/dirpath> -o <output/dirpath>
 Options:
   -h --help     Show this screen.
   --version     Show version.

--- a/EXIOBASE_conversion_software/excel2csv.py
+++ b/EXIOBASE_conversion_software/excel2csv.py
@@ -86,19 +86,7 @@ def xlsb2csv(xlsb, outdir, sheetnum = 2, csvOut=None):
     outDF.to_csv(csvOut, header=False, index=False)
     return outDF
 
-if __name__ == "__main__":
-
-    parser = argparse.ArgumentParser(description='Convert EXIOBASE .xslb file to csv')
-    parser.add_argument('-i','--import',
-                        dest='exfile',
-                        help='<Required> path to file to convert')
-
-    parser.add_argument('-o', '--outdir',
-                        dest='outdir',
-                        default='./',
-                        help='Output directory')
-
-    args = parser.parse_args()
+def excel2csv(args):
 
     exfile = args.exfile
     outdir = args.outdir

--- a/EXIOBASE_conversion_software/makeRDF.py
+++ b/EXIOBASE_conversion_software/makeRDF.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from rdflib import Graph, Literal, BNode, Namespace, RDF, URIRef
 from rdflib.namespace import DC, FOAF, XSD, OWL, RDFS
 import numpy as np
-from excel2csv import xlsb2csv
+from .excel2csv import xlsb2csv
 import pandas as pd
 def getAndSetNode(nID, ojDict, ojType="L"):
         '''
@@ -253,7 +253,7 @@ def makeRDF(inputDF):
         # asociate product to measure
         g.add(  (thisProduct, DEF.hasAmount, thisAmount))
     return g
-if __name__ == "__main__":
+def makeRdf():
 
     exfile = sys.argv[1]
     filename = Path(exfile).stem

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, BONSAI team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.md
+include *.txt
+include LICENSE

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ numpy = "*"
 pandas = "*"
 rdflib = "*"
 pyxlsb = "*"
+natsort = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ numpy = "*"
 pandas = "*"
 rdflib = "*"
 pyxlsb = "*"
-natsort = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "28c248b01c5f349036b209c498a1f4cbd6b1cb9169be0b92507e4102c7de9522"
+            "sha256": "fec42873f4692b191622679ba4d70e9759a960ab1ee1a036879b4d523df5e398"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,14 +22,6 @@
                 "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
             ],
             "version": "==0.6.0"
-        },
-        "natsort": {
-            "hashes": [
-                "sha256:41c9e0b5fb168d849656b3ea4d455385ec1036451167a9d977f94e63cb07a3d4",
-                "sha256:7207cddc510e1d5e728a7f73a0230f20a65e3346acd54856be6252291690d3ec"
-            ],
-            "index": "pypi",
-            "version": "==7.0.0"
         },
         "numpy": {
             "hashes": [
@@ -60,28 +52,23 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d",
-                "sha256:22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e",
-                "sha256:255920e63850dc512ce356233081098554d641ba99c3767dde9e9f35630f994b",
-                "sha256:26382aab9c119735908d94d2c5c08020a4a0a82969b7e5eefb92f902b3b30ad7",
-                "sha256:33970f4cacdd9a0ddb8f21e151bfb9f178afb7c36eb7c25b9094c02876f385c2",
-                "sha256:4545467a637e0e1393f7d05d61dace89689ad6d6f66f267f86fff737b702cce9",
-                "sha256:52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4",
-                "sha256:61741f5aeb252f39c3031d11405305b6d10ce663c53bc3112705d7ad66c013d0",
-                "sha256:6a3ac2c87e4e32a969921d1428525f09462770c349147aa8e9ab95f88c71ec71",
-                "sha256:7458c48e3d15b8aaa7d575be60e1e4dd70348efcd9376656b72fecd55c59a4c3",
-                "sha256:78bf638993219311377ce9836b3dc05f627a666d0dbc8cec37c0ff3c9ada673b",
-                "sha256:8153705d6545fd9eb6dd2bc79301bff08825d2e2f716d5dced48daafc2d0b81f",
-                "sha256:975c461accd14e89d71772e89108a050fa824c0b87a67d34cedf245f6681fc17",
-                "sha256:9962957a27bfb70ab64103d0a7b42fa59c642fb4ed4cb75d0227b7bb9228535d",
-                "sha256:adc3d3a3f9e59a38d923e90e20c4922fc62d1e5a03d083440468c6d8f3f1ae0a",
-                "sha256:bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf",
-                "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133",
-                "sha256:e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7",
-                "sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c"
+                "sha256:18bbce2e69855d42397486ee0bb79cb0e4c94af6679fd9392e32ffdb7fcfade0",
+                "sha256:35d07389efaf3c478d93725a226941c7fc14714814ba77d6d43b2c9e63ef4af5",
+                "sha256:3ea6cc86931f57f18b1240572216f09922d91b19ab8a01cf24734394a3db3bec",
+                "sha256:46b0a146e4ba744e350847244767ef297950e9ce02424734b2dd0befd77d9aff",
+                "sha256:66c1a49b47c0953dbc6864a6d2578c4c24610f6bb8e4ab165d49b8371aa7745f",
+                "sha256:6d5c2d2a3e42100700bac7fe762c17ba0a04d0355feac04bce74a1aa6c8be164",
+                "sha256:ab1aa2c50b7c6ba0eccebb146b4d80ed7f5804897b8d54ccddbe49f28c881a94",
+                "sha256:ae1ec10e34d22b0f699e38f346381630cae89d5050a2a61315a2be09e3435f99",
+                "sha256:b578df33338a09707bfe3e3939c9d46700948133bf829357c3c46795055c9376",
+                "sha256:bad77cf498362590ef3a30bc9e769f4fe4399d853861a1ddbefeea8cbf39906c",
+                "sha256:c36e4d44d34eaa503776a8fb57ba1305e680e178458c050c2fd8de67604fa209",
+                "sha256:d76a8ec22adf0323d362dac8c900b2c66e06eab984ecf04ef072866d8ab6c538",
+                "sha256:e8be4f6da608930c0d565240bfbe04fc6f5764d6a9214b02c6231cd5e223591d",
+                "sha256:f66c63f357ac31c913f4917f55348ce99c639031567c3284f01dff605da58264"
             ],
             "index": "pypi",
-            "version": "==0.25.3"
+            "version": "==1.0.0"
         },
         "pyparsing": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fec42873f4692b191622679ba4d70e9759a960ab1ee1a036879b4d523df5e398"
+            "sha256": "28c248b01c5f349036b209c498a1f4cbd6b1cb9169be0b92507e4102c7de9522"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,89 +23,94 @@
             ],
             "version": "==0.6.0"
         },
-        "numpy": {
+        "natsort": {
             "hashes": [
-                "sha256:0e2eed77804b2a6a88741f8fcac02c5499bba3953ec9c71e8b217fad4912c56c",
-                "sha256:1c666f04553ef70fda54adf097dbae7080645435fc273e2397f26bbf1d127bbb",
-                "sha256:1f46532afa7b2903bfb1b79becca2954c0a04389d19e03dc73f06b039048ac40",
-                "sha256:315fa1b1dfc16ae0f03f8fd1c55f23fd15368710f641d570236f3d78af55e340",
-                "sha256:3d5fcea4f5ed40c3280791d54da3ad2ecf896f4c87c877b113576b8280c59441",
-                "sha256:48241759b99d60aba63b0e590332c600fc4b46ad597c9b0a53f350b871ef0634",
-                "sha256:4b4f2924b36d857cf302aec369caac61e43500c17eeef0d7baacad1084c0ee84",
-                "sha256:54fe3b7ed9e7eb928bbc4318f954d133851865f062fa4bbb02ef8940bc67b5d2",
-                "sha256:5a8f021c70e6206c317974c93eaaf9bc2b56295b6b1cacccf88846e44a1f33fc",
-                "sha256:754a6be26d938e6ca91942804eb209307b73f806a1721176278a6038869a1686",
-                "sha256:771147e654e8b95eea1293174a94f34e2e77d5729ad44aefb62fbf8a79747a15",
-                "sha256:78a6f89da87eeb48014ec652a65c4ffde370c036d780a995edaeb121d3625621",
-                "sha256:7fde5c2a3a682a9e101e61d97696687ebdba47637611378b4127fe7e47fdf2bf",
-                "sha256:80d99399c97f646e873dd8ce87c38cfdbb668956bbc39bc1e6cac4b515bba2a0",
-                "sha256:88a72c1e45a0ae24d1f249a529d9f71fe82e6fa6a3fd61414b829396ec585900",
-                "sha256:a4f4460877a16ac73302a9c077ca545498d9fe64e6a81398d8e1a67e4695e3df",
-                "sha256:a61255a765b3ac73ee4b110b28fccfbf758c985677f526c2b4b39c48cc4b509d",
-                "sha256:ab4896a8c910b9a04c0142871d8800c76c8a2e5ff44763513e1dd9d9631ce897",
-                "sha256:abbd6b1c2ef6199f4b7ca9f818eb6b31f17b73a6110aadc4e4298c3f00fab24e",
-                "sha256:b16d88da290334e33ea992c56492326ea3b06233a00a1855414360b77ca72f26",
-                "sha256:b78a1defedb0e8f6ae1eb55fa6ac74ab42acc4569c3a2eacc2a407ee5d42ebcb",
-                "sha256:cfef82c43b8b29ca436560d51b2251d5117818a8d1fb74a8384a83c096745dad",
-                "sha256:d160e57731fcdec2beda807ebcabf39823c47e9409485b5a3a1db3a8c6ce763e"
+                "sha256:41c9e0b5fb168d849656b3ea4d455385ec1036451167a9d977f94e63cb07a3d4",
+                "sha256:7207cddc510e1d5e728a7f73a0230f20a65e3346acd54856be6252291690d3ec"
             ],
             "index": "pypi",
-            "version": "==1.16.3"
+            "version": "==7.0.0"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:1786a08236f2c92ae0e70423c45e1e62788ed33028f94ca99c4df03f5be6b3c6",
+                "sha256:17aa7a81fe7599a10f2b7d95856dc5cf84a4eefa45bc96123cbbc3ebc568994e",
+                "sha256:20b26aaa5b3da029942cdcce719b363dbe58696ad182aff0e5dcb1687ec946dc",
+                "sha256:2d75908ab3ced4223ccba595b48e538afa5ecc37405923d1fea6906d7c3a50bc",
+                "sha256:39d2c685af15d3ce682c99ce5925cc66efc824652e10990d2462dfe9b8918c6a",
+                "sha256:56bc8ded6fcd9adea90f65377438f9fea8c05fcf7c5ba766bef258d0da1554aa",
+                "sha256:590355aeade1a2eaba17617c19edccb7db8d78760175256e3cf94590a1a964f3",
+                "sha256:70a840a26f4e61defa7bdf811d7498a284ced303dfbc35acb7be12a39b2aa121",
+                "sha256:77c3bfe65d8560487052ad55c6998a04b654c2fbc36d546aef2b2e511e760971",
+                "sha256:9537eecf179f566fd1c160a2e912ca0b8e02d773af0a7a1120ad4f7507cd0d26",
+                "sha256:9acdf933c1fd263c513a2df3dceecea6f3ff4419d80bf238510976bf9bcb26cd",
+                "sha256:ae0975f42ab1f28364dcda3dde3cf6c1ddab3e1d4b2909da0cb0191fa9ca0480",
+                "sha256:b3af02ecc999c8003e538e60c89a2b37646b39b688d4e44d7373e11c2debabec",
+                "sha256:b6ff59cee96b454516e47e7721098e6ceebef435e3e21ac2d6c3b8b02628eb77",
+                "sha256:b765ed3930b92812aa698a455847141869ef755a87e099fddd4ccf9d81fffb57",
+                "sha256:c98c5ffd7d41611407a1103ae11c8b634ad6a43606eca3e2a5a269e5d6e8eb07",
+                "sha256:cf7eb6b1025d3e169989416b1adcd676624c2dbed9e3bcb7137f51bfc8cc2572",
+                "sha256:d92350c22b150c1cae7ebb0ee8b5670cc84848f6359cf6b5d8f86617098a9b73",
+                "sha256:e422c3152921cece8b6a2fb6b0b4d73b6579bd20ae075e7d15143e711f3ca2ca",
+                "sha256:e840f552a509e3380b0f0ec977e8124d0dc34dc0e68289ca28f4d7c1d0d79474",
+                "sha256:f3d0a94ad151870978fb93538e95411c83899c9dc63e6fb65542f769568ecfa5"
+            ],
+            "index": "pypi",
+            "version": "==1.18.1"
         },
         "pandas": {
             "hashes": [
-                "sha256:071e42b89b57baa17031af8c6b6bbd2e9a5c68c595bc6bf9adabd7a9ed125d3b",
-                "sha256:17450e25ae69e2e6b303817bdf26b2cd57f69595d8550a77c308be0cd0fd58fa",
-                "sha256:17916d818592c9ec891cbef2e90f98cc85e0f1e89ed0924c9b5220dc3209c846",
-                "sha256:2538f099ab0e9f9c9d09bbcd94b47fd889bad06dc7ae96b1ed583f1dc1a7a822",
-                "sha256:366f30710172cb45a6b4f43b66c220653b1ea50303fbbd94e50571637ffb9167",
-                "sha256:42e5ad741a0d09232efbc7fc648226ed93306551772fc8aecc6dce9f0e676794",
-                "sha256:4e718e7f395ba5bfe8b6f6aaf2ff1c65a09bb77a36af6394621434e7cc813204",
-                "sha256:4f919f409c433577a501e023943e582c57355d50a724c589e78bc1d551a535a2",
-                "sha256:4fe0d7e6438212e839fc5010c78b822664f1a824c0d263fd858f44131d9166e2",
-                "sha256:5149a6db3e74f23dc3f5a216c2c9ae2e12920aa2d4a5b77e44e5b804a5f93248",
-                "sha256:627594338d6dd995cfc0bacd8e654cd9e1252d2a7c959449228df6740d737eb8",
-                "sha256:83c702615052f2a0a7fb1dd289726e29ec87a27272d775cb77affe749cca28f8",
-                "sha256:8c872f7fdf3018b7891e1e3e86c55b190e6c5cee70cab771e8f246c855001296",
-                "sha256:90f116086063934afd51e61a802a943826d2aac572b2f7d55caaac51c13db5b5",
-                "sha256:a3352bacac12e1fc646213b998bce586f965c9d431773d9e91db27c7c48a1f7d",
-                "sha256:bcdd06007cca02d51350f96debe51331dec429ac8f93930a43eb8fb5639e3eb5",
-                "sha256:c1bd07ebc15285535f61ddd8c0c75d0d6293e80e1ee6d9a8d73f3f36954342d0",
-                "sha256:c9a4b7c55115eb278c19aa14b34fcf5920c8fe7797a09b7b053ddd6195ea89b3",
-                "sha256:cc8fc0c7a8d5951dc738f1c1447f71c43734244453616f32b8aa0ef6013a5dfb",
-                "sha256:d7b460bc316064540ce0c41c1438c416a40746fd8a4fb2999668bf18f3c4acf1"
+                "sha256:00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d",
+                "sha256:22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e",
+                "sha256:255920e63850dc512ce356233081098554d641ba99c3767dde9e9f35630f994b",
+                "sha256:26382aab9c119735908d94d2c5c08020a4a0a82969b7e5eefb92f902b3b30ad7",
+                "sha256:33970f4cacdd9a0ddb8f21e151bfb9f178afb7c36eb7c25b9094c02876f385c2",
+                "sha256:4545467a637e0e1393f7d05d61dace89689ad6d6f66f267f86fff737b702cce9",
+                "sha256:52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4",
+                "sha256:61741f5aeb252f39c3031d11405305b6d10ce663c53bc3112705d7ad66c013d0",
+                "sha256:6a3ac2c87e4e32a969921d1428525f09462770c349147aa8e9ab95f88c71ec71",
+                "sha256:7458c48e3d15b8aaa7d575be60e1e4dd70348efcd9376656b72fecd55c59a4c3",
+                "sha256:78bf638993219311377ce9836b3dc05f627a666d0dbc8cec37c0ff3c9ada673b",
+                "sha256:8153705d6545fd9eb6dd2bc79301bff08825d2e2f716d5dced48daafc2d0b81f",
+                "sha256:975c461accd14e89d71772e89108a050fa824c0b87a67d34cedf245f6681fc17",
+                "sha256:9962957a27bfb70ab64103d0a7b42fa59c642fb4ed4cb75d0227b7bb9228535d",
+                "sha256:adc3d3a3f9e59a38d923e90e20c4922fc62d1e5a03d083440468c6d8f3f1ae0a",
+                "sha256:bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf",
+                "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133",
+                "sha256:e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7",
+                "sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c"
             ],
             "index": "pypi",
-            "version": "==0.24.2"
+            "version": "==0.25.3"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
-                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.0"
+            "version": "==2.4.6"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
-                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "version": "==2.8.0"
+            "version": "==2.8.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
-                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
             ],
-            "version": "==2019.1"
+            "version": "==2019.3"
         },
         "pyxlsb": {
             "hashes": [
-                "sha256:b8755bdf0b0fd6ac4a52c04fd102a81972370f73d9621e6ec232fd23c8aa8dfc",
-                "sha256:de222defee2460958bbdc42e803c5b92ead569ff1d9c730b4176a398ef917030"
+                "sha256:28ae4cb0a37c525723093561057e81afb7b5b6c7f8e5f7cbfbab54fa0b6313d2",
+                "sha256:47e8230582de15ad9824a456d1d4cb36a6535f4ad5e5eb2464d31f0445b9db46"
             ],
             "index": "pypi",
-            "version": "==1.0.5"
+            "version": "==1.0.6"
         },
         "rdflib": {
             "hashes": [
@@ -117,10 +122,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.12.0"
+            "version": "==1.14.0"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -6,26 +6,40 @@ This readme explains the reasoning behind the choice to use the hybrid (rather t
 ## Run it
 
 ### Setup
+Clone repository
+```bash
+$ git clone git@github.com:BONSAMURAIS/EXIOBASE-conversion-software.git
+$ cd EXIOBASE-conversion-software
+```
+
+Create pipenv
 
 ```bash
-pipenv install
-pipenv shell
+$ pipenv install
+$ pipenv shell
 ```
 
+### Install
+```bash
+$ python setup.py install
+```
+
+
+## Usage
+### As a command line tool
 ### Convert `xslb` to `csv`
 ```
-python scripts/excel2csv.py -i data/MR_HSUP_2011_v3_3_17.xlsb -o data/
-
-python scripts/excel2csv.py -i data/MR_HUSE_2011_v3_3_17.xlsb -o data/
+$ excel2csv-cli -i data/MR_HSUP_2011_v3_3_17.xlsb -o data/
+$ excel2csv-cli -i data/MR_HUSE_2011_v3_3_17.xlsb -o data/
 ```
 
-### Convert `csv` to `ttl`
+### Convert `csv` to `nt`
 ```
-python scripts/csv2rdf.py -i data/MR_HSUP_2011_v3_3_17.csv -o data/  -c HSUP --flowtype output
-python scripts/csv2rdf.py -i data/MR_HUSE_2011_v3_3_17.csv -o data/  -c HUSE --flowtype input
+csv2rdf-cli -i data/MR_HSUP_2011_v3_3_17.csv -o data/  -c HSUP --flowtype output
+csv2rdf-cli -i data/MR_HUSE_2011_v3_3_17.csv -o data/  -c HUSE --flowtype input
 ```
 
-
+<!---
 ## Run with Docker
 
 ```bash
@@ -49,7 +63,7 @@ docker run --rm  -v "$PWD/data":/data bonsai/converter python3 scripts/csv2rdf.p
 
 docker run --rm  -v "$PWD/data":/data bonsai/converter python3 scripts/csv2rdf.py -i data/MR_HSUP_2011_v3_3_17.csv -o data/  -c HSUP --flowtype output
 ```
-
+-->
 
 
 ## Versions of Exiobase currently available

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = tests/*.py
+norecursedirs = venv, manual

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+docopt
+pyxlsb
+pandas
+rdflib

--- a/scripts/csv2rdf.py
+++ b/scripts/csv2rdf.py
@@ -41,23 +41,21 @@ from rdflib import Graph, Literal, BNode, Namespace, URIRef
 from rdflib.namespace import DCTERMS, FOAF, XSD, OWL, RDFS, RDF, SKOS
 
 
-def merge_files(args):
+def merge_files():
     onlyfiles = [f for f in listdir("data") if isfile(join("data", f)) and ".nt" in f]
 
-    g = Graph()
+    f = open("data/merged_flows.nt", "w")
     for file in natsorted(onlyfiles):
+        print("Working on file: {}".format(file))
         start = time.time()
-        print("Merging file:" + file)
-        g2 = Graph()
-        g2.parse("data/{}".format(file), format=(args.format))
-
-        g = g + g2
-
+        with open("data/{}".format(file), "r") as fp:
+            line = fp.readline()
+            while line and line.strip() != "":
+                f.write(line)
+                line = fp.readline()
         end = time.time()
         print("Time elasped", end - start)
 
-    print("Serializing files")
-    serialize_append_sub_graph(args, "merged", g, "final")
     print("All graphs merged")
 
 
@@ -397,7 +395,7 @@ if __name__ == "__main__":
     filename = re.sub(r'.csv$', '', file_name(csvfile))
 
 
-    merge_files(args)
+    merge_files()
     exit()
 
     print("Parsing file: {}".format(csvfile))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+from setuptools import setup, find_packages
+import os
+
+def package_files(directory):
+    paths = []
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
+
+setup(
+    name='EXIOBASE_conversion_software',
+    version="0.4",
+    packages=find_packages(),
+    author="BONSAI team",
+    author_email="info@bonsai.uno",
+    license=open('LICENSE').read(),
+    package_data={'EXIOBASE_conversion_software': package_files(os.path.join('EXIOBASE_conversion_software', 'data'))},
+    entry_points = {
+        'console_scripts': [
+            'csv2rdf-cli = EXIOBASE_conversion_software.bin.csv2rdf_cli:main',
+            'excel2csv-cli = EXIOBASE_conversion_software.bin.excel2csv_cli:main',
+        ]
+    },
+    install_requires=[
+        'numpy',
+        'docopt',
+        'pyxlsb',
+        'pandas',
+        'rdflib',
+    ],
+    url="https://github.com/BONSAMURAIS/EXIOBASE-conversion-software",
+    long_description=open('README.md').read(),
+    description="Extract Flows and Activities from the Exiobase HSUP and HUSE tables",
+    classifiers=[
+        'Intended Audience :: End Users/Desktop',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Scientific/Engineering :: Information Analysis',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Scientific/Engineering :: Visualization',
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author="BONSAI team",
     author_email="info@bonsai.uno",
     license=open('LICENSE').read(),
-    package_data={'EXIOBASE_conversion_software': package_files(os.path.join('EXIOBASE_conversion_software', 'data'))},
+    # package_data={'EXIOBASE_conversion_software': package_files(os.path.join('EXIOBASE_conversion_software', 'data'))},
     entry_points = {
         'console_scripts': [
             'csv2rdf-cli = EXIOBASE_conversion_software.bin.csv2rdf_cli:main',


### PR DESCRIPTION
**Reason for pull request**
This pull request converts the Exiobase-conversion-software to the python skeleton application format. 

This enables us to use the conversion-software as a cli-tool.

**New files**:

`bin/csv2rdf_cli.py`: This is the entrance point for the csv2rdf cli tool. 
`bin/excel2csv_cli.py`: Entrance point to the excel2csv cli tool.

Since both tools offer many input arguments, I found it easier to create two separate cli tools, than one big.

`setup.py`: setupfile for easy installation of the tools. 

**Extensions**
This pull request also features a new argument for the `csv2rdf` cli tool, to split the output rdf graph into multiple smaller graphs of self specified size. This was introduced due to memory limitations when parsing large csv files. This option only works for .nt files. 